### PR TITLE
Add a 'choose' def that takes TypeTags rather than LTags

### DIFF
--- a/core/src/main/scala-2/com/babylonhealth/lit/core/ChoiceImplicits.scala
+++ b/core/src/main/scala-2/com/babylonhealth/lit/core/ChoiceImplicits.scala
@@ -1,8 +1,9 @@
 package com.babylonhealth.lit.core
 
 import scala.annotation.implicitNotFound
+import scala.reflect.runtime.universe.TypeTag
 
-import izumi.reflect.macrortti.LTag
+import izumi.reflect.macrortti.{ LTT, LTag }
 
 import com.babylonhealth.lit.core.\/.\::/
 import com.babylonhealth.lit.core.model.typeSuffixMap
@@ -53,6 +54,11 @@ object ChoiceImplicits {
   def choice[U <: _ \/ _: LTag, S: LTag](t: S)(implicit
       @implicitNotFound("Cannot prove that ${S} is a viable type for union ${U}") witness: UnionWitness[U, S]): Choice[U] =
     Choice.fromValAndSuffix[U, S](t, witness.suffix)
+
+  // Semantically redundant, but works around a macro expansion issue in intelliJ
+  def choose[U <: _ \/ _: TypeTag, S: TypeTag](t: S)(implicit
+      @implicitNotFound("Cannot prove that ${S} is a viable type for union ${U}") witness: UnionWitness[U, S]): Choice[U] =
+    Choice.fromValAndSuffix[U, S](t, witness.suffix)(LTag(LTT[U]))
 
   // Use case for this constructor is specifically extensions which limit their value range to a single enum
   def choiceFromEnum[U <: _ \/ _: LTag, S <: EnumBase: LTag](t: S)(implicit


### PR DESCRIPTION
Workaround for intelliJ bug (`choice` will be incorrectly highlighted even when valid)
Before:
<img width="601" alt="Screenshot 2021-08-23 at 14 16 14" src="https://user-images.githubusercontent.com/2494489/130453752-0d52c0d0-c4f8-4b2b-8d47-88008ff7c1bc.png">
After: 
<img width="434" alt="Screenshot 2021-08-23 at 14 16 07" src="https://user-images.githubusercontent.com/2494489/130453788-ab7d3aa9-6f95-42a7-9155-cfbb2fe85f11.png">

